### PR TITLE
Add content type in copy over

### DIFF
--- a/S3CopyToChina-Main.py
+++ b/S3CopyToChina-Main.py
@@ -71,7 +71,7 @@ def lambda_handler(event, context):
                 else:
                     # If file size > 5MB, invoke other Lambda to transfer S3 parts by range in parallel.
                     print('Split object '+bucket+'/'+key+' to parts to process by Lambda.')
-                    mpu_response = s3CNclient.create_multipart_upload(Bucket=dst_bucket, Key=key)
+                    mpu_response = s3CNclient.create_multipart_upload(Bucket=dst_bucket, Key=key, ContentType=head_response['ContentType'])
                     uploadid = mpu_response['UploadId']
                     part_size = 5 * 1024 * 1024
                     position = 0
@@ -116,3 +116,4 @@ def lambda_handler(event, context):
             print(traceback.format_exc())
 
     return (bucket, key)
+    

--- a/S3CopyToChina-Single.py
+++ b/S3CopyToChina-Single.py
@@ -36,10 +36,15 @@ def lambda_handler(event, context):
                 'complete':{'S': 'N'},
                 'start_time':{'N': str(time.time())}
                 })
-
-    s3client.download_file(bucket, key, file_name)
-    s3CNclient.upload_file(file_name, dst_bucket, key)
-
+    
+    response = s3client.get_object(Bucket=bucket,Key=key)
+    f = open(file_name,'wb')
+    f.write(response['Body'].read())
+    f.close()
+    
+    ExtraArgs={"ContentType": response['ContentType']}
+    s3CNclient.upload_file(file_name, dst_bucket, key, ExtraArgs=ExtraArgs)
+    
     ddb.update_item(TableName='S3SingleResult',
         Key={
             "id": {"S": id}
@@ -63,7 +68,3 @@ def lambda_handler(event, context):
         os.remove(file_name)
         
     print('Complete copying S3 file '+bucket+'/'+key+ ' to China S3 bucket '+dst_bucket)
-
-
-
-


### PR DESCRIPTION
Hi ZhangPin,

We have a use case to sync files from AWS Global to AWS CN, so I read your blog, and tried your code, it is helpful and works great when sync over objects,

From testing I found when copy over an object, the new object in CN s3 bucket will not have right 'Content-Type', which will cause the object always to be downloaded if it hosting with S3, 

So I make a minor improve by adding the content type in both Main and Single python function to 
 also copy over the original content-type in the same call,

Please review my PR and let me know if you have any questions, @milan9527 

Thanks for the great project :+1: 